### PR TITLE
Bugfix/react does not call blur on element

### DIFF
--- a/src/droppable.ts
+++ b/src/droppable.ts
@@ -171,7 +171,7 @@ export default class Droppable {
     }
 
     private onElementFocusOut() {
-        this.elementKeyDownEventRemover();
+        if (this.elementKeyDownEventRemover) this.elementKeyDownEventRemover();
     }
 
     private onVirtualInputElementChange(e: Event) {

--- a/test/droppable.test.ts
+++ b/test/droppable.test.ts
@@ -549,19 +549,34 @@ describe('Droppable', () => {
         });
 
         describe('onElementFocusOut()', () => {
-            it('should call this.elementKeyDownEventRemover()', () => {
-                const element = document.createElement('div');
-                const droppable = new Droppable({
-                    element
+            describe('when this.elementKeyDownEventRemover is defined', () => {
+                it('should call this.elementKeyDownEventRemover()', () => {
+                    const element = document.createElement('div');
+                    const droppable = new Droppable({
+                        element
+                    });
+
+                    const mockFn = jest.fn();
+
+                    droppable['elementKeyDownEventRemover'] = mockFn;
+
+                    droppable['onElementFocusOut']();
+
+                    expect(mockFn).toHaveBeenCalled();
                 });
+            });
 
-                const mockFn = jest.fn();
-
-                droppable['elementKeyDownEventRemover'] = mockFn;
-
-                droppable['onElementFocusOut']();
-
-                expect(mockFn).toHaveBeenCalled();
+            describe('when this.elementKeyDownEventRemover is not defined', () => {
+                it('should not throw an error', () => {
+                    const element = document.createElement('div');
+                    const droppable = new Droppable({
+                        element
+                    });
+                    delete droppable['elementKeyDownEventRemover'];
+                    expect(() => {
+                        droppable['onElementFocusOut']();
+                    }).not.toThrow();
+                });
             });
         });
 


### PR DESCRIPTION
Seems like its not safe to assume an item will be focused before focusedout, at least in the case of React. 
