### PR TITLE
Use singular "they" instead of "him"

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ const latestDroppedFiles = droppable.getLatestDroppedFiles();
 ```
 
 ### Trigger prompt for files
-Sometimes you will want to prompt the user for files without him dropping files or clicking the element.
+Sometimes you will want to prompt the user for files without they dropping files or clicking the element.
 ```typescript
 droppable.promptForFiles();
 ```

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ const latestDroppedFiles = droppable.getLatestDroppedFiles();
 ```
 
 ### Trigger prompt for files
-Sometimes you will want to prompt the user for files without they dropping files or clicking the element.
+Sometimes you will want to prompt the users for files without them dropping files or clicking the element.
 ```typescript
 droppable.promptForFiles();
 ```


### PR DESCRIPTION
Use singular "they" instead of "him" to make the sentence gender neutral.